### PR TITLE
Remove copying of server AMIs to other regions.

### DIFF
--- a/go-server-packer.json
+++ b/go-server-packer.json
@@ -30,23 +30,7 @@
         "GoCD-Version": "{{user `gocd_version`}}",
         "Name": "GoCD Server {{user `gocd_version`}}",
         "Type": "server"
-      },
-      "ami_regions": [
-        "ap-south-1",
-        "eu-west-2",
-        "eu-west-1",
-        "ap-northeast-2",
-        "ap-northeast-1",
-        "sa-east-1",
-        "ca-central-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "eu-central-1",
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2"
-      ]
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Since we don't know whether the AMIs are even being used, until there is a request to provide the server AMI in other regions, it isn't necessary to copy the built AMI to other regions. This is a breaking change that needs to be announced in 18.7.0