### PR TITLE
Copy AMI to one extra region

### DIFF
--- a/go-server-demo-packer.json
+++ b/go-server-demo-packer.json
@@ -2,7 +2,8 @@
   "variables": {
     "gocd_version": "",
     "instance_type": "c5.large",
-    "region": "{{env `REGION`}}"
+    "region": "{{env `REGION`}}",
+    "extra_ami_region_to_copy_to": "{{env `EXTRA_AMI_REGION_TO_COPY_TO`}}"
   },
   "builders": [
     {
@@ -18,6 +19,7 @@
         "most_recent": true
       },
       "ami_groups": "all",
+      "ami_regions": ["{{user `extra_ami_region_to_copy_to`}}"],
       "instance_type": "{{user `instance_type`}}",
       "ssh_username": "ec2-user",
       "ami_name": "GoCD Demo {{user `gocd_version`}}",

--- a/go-server-packer.json
+++ b/go-server-packer.json
@@ -2,7 +2,8 @@
   "variables": {
     "gocd_version": "",
     "instance_type": "c5.large",
-    "region": "{{env `REGION`}}"
+    "region": "{{env `REGION`}}",
+    "extra_ami_region_to_copy_to": "{{env `EXTRA_AMI_REGION_TO_COPY_TO`}}"
   },
   "builders": [
     {
@@ -18,6 +19,7 @@
         "most_recent": true
       },
       "ami_groups": "all",
+      "ami_regions": ["{{user `extra_ami_region_to_copy_to`}}"],
       "instance_type": "{{user `instance_type`}}",
       "ssh_username": "ec2-user",
       "ami_name": "GoCD Server {{user `gocd_version`}}",


### PR DESCRIPTION
This allows setting the environment variable `EXTRA_AMI_REGION_TO_COPY_TO` so that the generated AMIs can be copied to one extra region. This can be a region different from the one specified in the environment variable `REGION`.

Link to: [amazon-ebs builder docs for packer](https://www.packer.io/docs/builders/amazon-ebs.html).

Ideally, `REGION` would be set to an AWS region and it just creates the AMI there. But, in some cases it's not possible to set `REGION` to be the destination, since `REGION` is used to start an EC2 instance to create the AMI. So, you can then set `EXTRA_AMI_REGION_TO_COPY_TO` to the real destination region for the AMI.

Side effect: You now have two AMIs, one in `REGION` and one in `EXTRA_AMI_REGION_TO_COPY_TO`. In this particular case, it's not a big problem to have it, imo. Haven't bothered deregistering and deleting the EBS snapshot. I can, if you think we need it, @bdpiparva or @GaneshSPatil.

Related to: https://github.com/gocd/build_utilities/pull/58

Also: Added `EXTRA_AMI_REGION_TO_COPY_TO` to `us-east-1` in the publish pipeline.